### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 vim-command-t (5.0.3-2) UNRELEASED; urgency=medium
 
   * Wrap long lines in changelog entries: 5.0.3-1.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 03:44:39 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,13 @@
+vim-command-t (5.0.3-2) UNRELEASED; urgency=medium
+
+  * Wrap long lines in changelog entries: 5.0.3-1.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 03:44:39 +0000
+
 vim-command-t (5.0.3-1) unstable; urgency=medium
 
-  * Improve README.source with more steps for dealing with a new upstream version
+  * Improve README.source with more steps for dealing with a new upstream
+    version
   * New upstream release
 
  -- Sam Morris <sam@robots.org.uk>  Wed, 17 Jul 2019 17:59:12 +0100

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/wincent/command-t/issues
+Bug-Submit: https://github.com/wincent/command-t/issues/new
+Repository: https://github.com/wincent/command-t.git
+Repository-Browse: https://github.com/wincent/command-t


### PR DESCRIPTION
Fix some issues reported by lintian
* Wrap long lines in changelog entries: 5.0.3-1. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/vim-command-t/923f0b30-485c-4ab9-a35d-35e7b1aa1c97.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/47/6cd92f99f91ef540d768377a4503c4848d5119.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b0/fb9944dad5a6c4646de95aafb143515260ab4a.debug

No differences were encountered between the control files of package \*\*vim-command-t\*\*
### Control files of package vim-command-t-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-b0fb9944dad5a6c4646de95aafb143515260ab4a-] {+476cd92f99f91ef540d768377a4503c4848d5119+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/923f0b30-485c-4ab9-a35d-35e7b1aa1c97/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/923f0b30-485c-4ab9-a35d-35e7b1aa1c97/diffoscope)).
