### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: editors
 Priority: optional
 Build-Depends:
  bundler,
- debhelper-compat (= 10),
+ debhelper-compat (= 13),
  dh-vim-addon,
  rake,
  ruby,

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/wincent/command-t/issues
+Bug-Submit: https://github.com/wincent/command-t/issues/new
+Repository: https://github.com/wincent/command-t.git
+Repository-Browse: https://github.com/wincent/command-t


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 10 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/vim-command-t/776934af-6822-4ec7-8b91-123a58cd9804.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/66/c85ba0f79a94317b9a70dc0cb79a9f6bbab0cf.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/58/f8118a149fe6b91f2df99b79c7996e572fbc80.debug

No differences were encountered between the control files of package \*\*vim-command-t\*\*
### Control files of package vim-command-t-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-58f8118a149fe6b91f2df99b79c7996e572fbc80-] {+66c85ba0f79a94317b9a70dc0cb79a9f6bbab0cf+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/776934af-6822-4ec7-8b91-123a58cd9804/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/776934af-6822-4ec7-8b91-123a58cd9804/diffoscope)).
